### PR TITLE
Mixed up event handlers

### DIFF
--- a/TellCoreClient.cs
+++ b/TellCoreClient.cs
@@ -323,7 +323,7 @@ namespace TellCore
                 {
                     deviceStateChanged -= value;
 
-                    if (deviceChanged == null && deviceStateChangedCallbackId.HasValue)
+                    if (deviceStateChanged == null && deviceStateChangedCallbackId.HasValue)
                         NativeMethods.tdUnregisterCallback(deviceStateChangedCallbackId.Value);
                 }
             }
@@ -334,7 +334,7 @@ namespace TellCore
             add
             {
                 // If this is the first subscriber to the event we'll register with telldus
-                if (deviceStateChanged == null)
+                if (rawDeviceEvent == null)
                     rawDeviceEventCallbackId = NativeMethods.tdRegisterRawDeviceEvent(OnRawDeviceEvent, IntPtr.Zero);
 
                 rawDeviceEvent += value;
@@ -342,11 +342,11 @@ namespace TellCore
             remove
             {
                 // Need this double check to prevent accidental tdUnregisterCallback
-                if (deviceStateChanged != null)
+                if (rawDeviceEvent != null)
                 {
                     rawDeviceEvent -= value;
 
-                    if (deviceChanged == null && rawDeviceEventCallbackId.HasValue)
+                    if (rawDeviceEvent == null && rawDeviceEventCallbackId.HasValue)
                         NativeMethods.tdUnregisterCallback(rawDeviceEventCallbackId.Value);
                 }
             }


### PR DESCRIPTION
I was working on a wrapper around TelldusCore.dll myself when I stumbled on your project. After I had read through your code I found something that did not look right:

1) Can only unregister callback deviceStateChangedCallbackId if I had previously registered for deviceChanged.
2) Will call tdRegisterRawDeviceEvent every time I register for RawDeviceEvent, if I have not aldready registred for DeviceStateChanged, which in turn prevents tdRegisterRawDeviceEvent from being called when I am registring RawDeviceEvent.
3) Can only unregister callback rawDeviceEventCallbackId if I had previously registered for deviceChanged.
