### PR TITLE
Add support for sensors

### DIFF
--- a/TellCore/Enumerations/SensorValueType.cs
+++ b/TellCore/Enumerations/SensorValueType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace TellCore
+{
+    [Flags]
+    public enum SensorValueType
+    {
+        Temperature = 1,
+     	Humidity = 2,
+     	RainRate = 4,
+     	RainTotal = 8,
+     	WindDirection = 16,
+     	WindAverage = 32,
+     	WindGust = 64
+    }
+}

--- a/TellCore/Models/SensorReadingResult.cs
+++ b/TellCore/Models/SensorReadingResult.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TellCore
+{
+    public class SensorReadingResult
+    {
+        public string Value { get; set; }
+        public DateTime TimeStamp { get; set; }
+    }
+}

--- a/TellCore/Models/SensorResult.cs
+++ b/TellCore/Models/SensorResult.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace TellCore
+{
+    public class SensorResult
+    {
+        public TellstickResult Result { get; set; }
+        public SensorValueType Type { get; set; }
+        public string Protocol { get; set; }
+        public string Model { get; set; }
+        public int SensorId { get; set; }
+    }
+}

--- a/TellCore/NativeMethods.cs
+++ b/TellCore/NativeMethods.cs
@@ -128,6 +128,25 @@ namespace TellCore
         [DllImport("TelldusCore.dll")]
         internal static extern int tdRegisterDeviceChangeEvent(DeviceChangeEventFunctionDelegate deviceChangeEventFunction, IntPtr context);
 
+        [DllImport("TelldusCore.dll")]
+        public static extern TellstickResult tdSensor(
+            IntPtr protocol,
+            int protocolLength, 
+            IntPtr model, 
+            int modelLength,
+            ref int id,
+            ref int dataTypes);
+
+        [DllImport("TelldusCore.dll")]
+        public static extern int tdSensorValue(
+            IntPtr protocol, 
+            IntPtr model, 
+            int id, 
+            int dataType,
+            IntPtr value, 
+            int valueLength, 
+            ref int timestamp);
+        
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate void EventFunctionDelegate(
             int deviceId, 

--- a/TellCore/TellCore.csproj
+++ b/TellCore/TellCore.csproj
@@ -44,10 +44,13 @@
     <Compile Include="Enumerations\DeviceChange.cs" />
     <Compile Include="Enumerations\DeviceChangeType.cs" />
     <Compile Include="Enumerations\DeviceMethod.cs" />
+    <Compile Include="Models\SensorReadingResult.cs" />
+    <Compile Include="Enumerations\SensorValueType.cs" />
     <Compile Include="Enumerations\TellstickResult.cs" />
     <Compile Include="Events\DeviceChangedEventArgs.cs" />
     <Compile Include="Events\RawDeviceEventArgs.cs" />
     <Compile Include="Events\DeviceStateChangedEventArgs.cs" />
+    <Compile Include="Models\SensorResult.cs" />
     <Compile Include="TellCoreClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Enumerations\DeviceType.cs" />

--- a/TellCore/TellCore.csproj
+++ b/TellCore/TellCore.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Enumerations\DeviceType.cs" />
     <Compile Include="NativeMethods.cs" />
+    <Compile Include="Utils\DisposableStringPointer.cs" />
     <Compile Include="Utils\TelldusUtf8Marshaler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/TellCore/Utils/DisposableStringPointer.cs
+++ b/TellCore/Utils/DisposableStringPointer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TellCore.Utils
+{
+    public class DisposableStringPointer : IDisposable
+    {
+        public string Value
+        {
+            get { return (string)OutMarshaler.MarshalNativeToManaged(Pointer); }
+        }
+
+        public IntPtr Pointer { get; set; }
+
+        static TelldusUtf8Marshaler InMarshaler { get; set; }
+        static TelldusUtf8Marshaler OutMarshaler { get; set; }
+
+        static DisposableStringPointer()
+        {
+            InMarshaler = new TelldusUtf8Marshaler(MarshalDirection.In);
+            OutMarshaler = new TelldusUtf8Marshaler(MarshalDirection.Out);
+        }
+
+        public DisposableStringPointer()
+            : this(string.Empty)
+        {
+        }
+
+        public DisposableStringPointer(string value)
+        {
+            Pointer = InMarshaler.MarshalManagedToNative(value);
+        }
+
+        public void Dispose()
+        {
+            InMarshaler.CleanUpNativeData(Pointer);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for polling for sensors and reading their respective values. Note that we cannot use `TelldusUtf8Marshaler` in the same way we did earlier for these two function calls. The marshaller works good for when a pointer needs to be converted one-way (managed to native or native to managed) but for this case we need to first provide `TelldusCore` with a pointer, allow `TelldusCore` to populate it, and then convert it back to a string.
